### PR TITLE
Crediting Fork Author

### DIFF
--- a/plugin.php
+++ b/plugin.php
@@ -3,9 +3,9 @@
 Plugin Name: Fancy Pokemon Urls
 Description: Short URLs like <tt>https://short.rip/ModestAlolanDuosion</tt>
 Version: 0.1
-Plugin Author: Forte
+Author: Forte
 Plugin URI: https://github.com/fortepc/Fancy-Pokemon-Short-Urls
-
+Author URI: https://github.com/fortepc/
 
 
 Original Plugin Name: Word Based Short Urls

--- a/plugin.php
+++ b/plugin.php
@@ -5,7 +5,6 @@ Description: Short URLs like <tt>https://short.rip/ModestAlolanDuosion</tt>
 Version: 0.1
 Plugin Author: Forte
 Plugin URI: https://github.com/fortepc/Fancy-Pokemon-Short-Urls
-Fork Creator: Forte
 
 
 

--- a/plugin.php
+++ b/plugin.php
@@ -4,7 +4,7 @@ Plugin Name: Fancy Pokemon Urls
 Description: Short URLs like <tt>https://short.rip/ModestAlolanDuosion</tt>
 Version: 0.1
 Modifier: Forte
-
+Plugin URI: https://github.com/fortepc/Fancy-Pokemon-Short-Urls
 
 Original Plugin Name: Word Based Short Urls
 Original Plugin Author: Ozh 

--- a/plugin.php
+++ b/plugin.php
@@ -3,8 +3,11 @@
 Plugin Name: Fancy Pokemon Urls
 Description: Short URLs like <tt>https://short.rip/ModestAlolanDuosion</tt>
 Version: 0.1
-Modifier: Forte
+Plugin Author: Forte
 Plugin URI: https://github.com/fortepc/Fancy-Pokemon-Short-Urls
+Fork Creator: Forte
+
+
 
 Original Plugin Name: Word Based Short Urls
 Original Plugin Author: Ozh 


### PR DESCRIPTION
This minor change adds the Github Repo Link of the Forked author to the YOURLS/PLUGINS page. This allows users to click the name of the Plugin name on the Page to be brought to GitHub.

This also adds proper crediting to the Fork Editor on the Plugins Page.